### PR TITLE
Refactor KeyCreationOptions

### DIFF
--- a/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
+++ b/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
@@ -38,7 +38,7 @@ public static class CertificateWorkerCore
       ArgumentNullException.ThrowIfNull(client);
       ArgumentNullException.ThrowIfNull(tokenCredential);
 
-      keyOptions ??= new KeyCreationOptions();
+      keyOptions ??= new RsaKeyCreationOptions();
 
       var certificatePolicy = CreateCertificatePolicy(WellKnownIssuerNames.Self, subjectNameValue, expireMonth, keyOptions, reuseKey);
 
@@ -46,7 +46,7 @@ public static class CertificateWorkerCore
       var operation = await client.StartCreateCertificateAsync(certificateName, certificatePolicy);
 
       // Wait for the certificate to be created, get the public and signing key.
-      _= await operation.WaitForCompletionAsync();
+      _ = await operation.WaitForCompletionAsync();
 
       using var x509Cert = X509CertificateLoader.LoadCertificate(operation.Value.Cer);
       var privateKeyId = operation.Value.KeyId;
@@ -133,16 +133,7 @@ public static class CertificateWorkerCore
       ArgumentNullException.ThrowIfNull(subjectNameValue);
       ArgumentNullException.ThrowIfNull(keyOptions);
 
-      var keyType = keyOptions.KeyType.ToUpperInvariant() switch
-      {
-         "RSA" => CertificateKeyType.Rsa,
-         "RSAHSM" => CertificateKeyType.RsaHsm,
-         "EC" => CertificateKeyType.Ec,
-         "ECHSM" => CertificateKeyType.EcHsm,
-         _ => throw new ArgumentOutOfRangeException(nameof(keyOptions.KeyType), keyOptions.KeyType, "Unsupported KeyType."),
-      };
-
-      bool isEc = keyType == CertificateKeyType.Ec || keyType == CertificateKeyType.EcHsm;
+      var keyType = keyOptions.GetCertificateKeyType();
 
       var policy = new CertificatePolicy(issuerName, subjectNameValue)
       {
@@ -152,20 +143,13 @@ public static class CertificateWorkerCore
          ValidityInMonths = expireMonths,
       };
 
-      if (isEc)
+      if (keyOptions is EcKeyCreationOptions ecOptions)
       {
-         policy.KeyCurveName = keyOptions.KeyCurveName.ToUpperInvariant() switch
-         {
-            "P256" => CertificateKeyCurveName.P256,
-            "P256K" => CertificateKeyCurveName.P256K,
-            "P384" => CertificateKeyCurveName.P384,
-            "P521" => CertificateKeyCurveName.P521,
-            _ => throw new ArgumentOutOfRangeException(nameof(keyOptions), keyOptions.KeyCurveName, "Unsupported KeyCurveName."),
-         };
+         policy.KeyCurveName = ecOptions.GetCertificateKeyCurveName();
       }
-      else
+      else if (keyOptions is RsaKeyCreationOptions rsaOptions)
       {
-         policy.KeySize = keyOptions.KeySize;
+         policy.KeySize = rsaOptions.KeySize;
       }
 
       return policy;
@@ -180,21 +164,26 @@ public static class CertificateWorkerCore
    {
       ArgumentNullException.ThrowIfNull(keyOptions);
 
-      bool isEcKey = keyOptions.KeyType.Equals("Ec", StringComparison.OrdinalIgnoreCase) || keyOptions.KeyType.Equals("EcHsm", StringComparison.OrdinalIgnoreCase);
-      return isEcKey ? keyOptions.KeyCurveName.ToUpperInvariant() switch
+      return keyOptions switch
+      {
+         EcKeyCreationOptions ecOptions => ecOptions.KeyCurveName.ToUpperInvariant() switch
          {
             "P256" or "P256K" => HashAlgorithmName.SHA256,
             "P521" => HashAlgorithmName.SHA512,
-            _ => HashAlgorithmName.SHA384
-         }
-         : HashAlgorithmName.SHA384;
+            _ => HashAlgorithmName.SHA384,
+         },
+         _ => HashAlgorithmName.SHA384,
+      };
    }
 
    public static RSASignaturePadding? GetRSASignaturePadding(KeyCreationOptions keyOptions)
    {
       ArgumentNullException.ThrowIfNull(keyOptions);
 
-      bool isEcKey = keyOptions.KeyType.Equals("Ec", StringComparison.OrdinalIgnoreCase) || keyOptions.KeyType.Equals("EcHsm", StringComparison.OrdinalIgnoreCase);
-      return isEcKey ? null : RSASignaturePadding.Pkcs1;
+      return keyOptions switch
+      {
+         RsaKeyCreationOptions => RSASignaturePadding.Pkcs1,
+         _ => null,
+      };
    }
 }

--- a/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
+++ b/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
@@ -163,10 +163,10 @@ public static class CertificateWorkerCore
 
       return keyOptions switch
       {
-         EcKeyCreationOptions ecOptions => ecOptions.KeyCurveName.ToUpperInvariant() switch
+         EcKeyCreationOptions ecOptions => ecOptions.KeyCurve switch
          {
-            "P256" or "P256K" => HashAlgorithmName.SHA256,
-            "P521" => HashAlgorithmName.SHA512,
+            EcKeyCurve.P256 or EcKeyCurve.P256K => HashAlgorithmName.SHA256,
+            EcKeyCurve.P521 => HashAlgorithmName.SHA512,
             _ => HashAlgorithmName.SHA384,
          },
          _ => HashAlgorithmName.SHA384,

--- a/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
+++ b/src/AzureCertTools/AzureCertCore/CertificateWorkerCore.cs
@@ -17,9 +17,6 @@ namespace CertTools.AzureCertCore;
 /// </summary>
 public static class CertificateWorkerCore
 {
-   /// <summary>RSA key size in bits</summary>
-   public const int RsaKeySize = 4096;
-
    /// <summary>
    /// Create a self signed certificate with the given subject name in Azure Key Vault.
    /// </summary>

--- a/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
+++ b/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
@@ -28,13 +28,21 @@ public abstract class KeyCreationOptions
 /// </summary>
 public class RsaKeyCreationOptions : KeyCreationOptions
 {
-   /// <summary>Default RSA key size in bits.</summary>
-   public const int DefaultKeySize = 4096;
-
    /// <summary>
    /// Gets or sets the RSA key size in bits. Supported values: 2048, 3072, 4096.
    /// </summary>
-   public int KeySize { get; init; } = DefaultKeySize;
+   public int KeySize { get; init; } = 4096;
+}
+
+/// <summary>
+/// Enumeration of supported EC key curves for EC key creation in Azure Key Vault.
+/// </summary>
+public enum EcKeyCurve
+{
+   P256,
+   P256K,
+   P384,
+   P521
 }
 
 /// <summary>
@@ -42,11 +50,8 @@ public class RsaKeyCreationOptions : KeyCreationOptions
 /// </summary>
 public class EcKeyCreationOptions : KeyCreationOptions
 {
-   /// <summary>Default EC key curve name.</summary>
-   public const string DefaultKeyCurveName = "P384";
-
    /// <summary>
-   /// Gets or sets the EC key curve name. Supported values: P256, P256K, P384, P521.
+   /// Gets or sets the EC key curve
    /// </summary>
-   public string KeyCurveName { get; init; } = DefaultKeyCurveName;
+   public EcKeyCurve KeyCurve { get; init; } = EcKeyCurve.P384;
 }

--- a/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
+++ b/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
@@ -10,34 +10,43 @@ namespace CertTools.AzureCertCore;
 /// <summary>
 /// Container class for the key creation options controlling how the private key for a certificate is created in Azure Key Vault.
 /// </summary>
-public class KeyCreationOptions
+public abstract class KeyCreationOptions
 {
-   /// <summary>Default key type: RSA software-backed.</summary>
-   public const string DefaultKeyType = "Rsa";
-
-   /// <summary>Default EC key curve name.</summary>
-   public const string DefaultKeyCurveName = "P384";
-
-   /// <summary>Default RSA key size in bits.</summary>
-   public const int DefaultKeySize = 4096;
-
-   /// <summary>
-   /// Gets or sets the key type. Supported values: Ec, EcHsm, Rsa, RsaHsm.
-   /// </summary>
-   public string KeyType { get; init; } = DefaultKeyType;
-
    /// <summary>
    /// Gets or sets a value indicating whether the private key is exportable from Azure Key Vault.
    /// </summary>
    public bool Exportable { get; init; } = false;
 
    /// <summary>
-   /// Gets or sets the EC key curve name. Applicable only for EC and EcHsm key types. Supported values: P256, P256K, P384, P521.
+   /// Gets or sets a value indicating whether the private key should be created in an HSM-protected key vault storage.
    /// </summary>
-   public string KeyCurveName { get; init; } = DefaultKeyCurveName;
+   public bool HsmBacked { get; init; } = false;
+}
+
+/// <summary>
+/// Container class for the RSA key creation options controlling how the RSA private key for a certificate is created in Azure Key Vault.
+/// </summary>
+public class RsaKeyCreationOptions : KeyCreationOptions
+{
+   /// <summary>Default RSA key size in bits.</summary>
+   public const int DefaultKeySize = 4096;
 
    /// <summary>
-   /// Gets or sets the RSA key size in bits. Applicable only for Rsa and RsaHsm key types. Supported values: 2048, 3072, 4096.
+   /// Gets or sets the RSA key size in bits. Supported values: 2048, 3072, 4096.
    /// </summary>
    public int KeySize { get; init; } = DefaultKeySize;
+}
+
+/// <summary>
+/// Container class for the EC key creation options controlling how the EC private key for a certificate is created in Azure Key Vault.
+/// </summary>
+public class EcKeyCreationOptions : KeyCreationOptions
+{
+   /// <summary>Default EC key curve name.</summary>
+   public const string DefaultKeyCurveName = "P384";
+
+   /// <summary>
+   /// Gets or sets the EC key curve name. Supported values: P256, P256K, P384, P521.
+   /// </summary>
+   public string KeyCurveName { get; init; } = DefaultKeyCurveName;
 }

--- a/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
+++ b/src/AzureCertTools/AzureCertCore/KeyCreationOptions.cs
@@ -28,10 +28,13 @@ public abstract class KeyCreationOptions
 /// </summary>
 public class RsaKeyCreationOptions : KeyCreationOptions
 {
+   /// <summary>Default RSA key size in bits.</summary>
+   public const int DefaultKeySize = 4096;
+
    /// <summary>
-   /// Gets or sets the RSA key size in bits. Supported values: 2048, 3072, 4096.
+   /// Gets or sets the RSA key size in bits. Supported values: 2048, 3072, 4096. Default is 4096.
    /// </summary>
-   public int KeySize { get; init; } = 4096;
+   public int KeySize { get; init; } = DefaultKeySize;
 }
 
 /// <summary>
@@ -51,7 +54,7 @@ public enum EcKeyCurve
 public class EcKeyCreationOptions : KeyCreationOptions
 {
    /// <summary>
-   /// Gets or sets the EC key curve
+   /// Gets or sets the EC key curve. Supported values: P256, P256K, P384, P521. Default is P384.
    /// </summary>
    public EcKeyCurve KeyCurve { get; init; } = EcKeyCurve.P384;
 }

--- a/src/AzureCertTools/AzureCertCore/KeyCreationOptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/KeyCreationOptionsExtensions.cs
@@ -10,6 +10,10 @@ using Azure.Security.KeyVault.Certificates;
 
 namespace CertTools.AzureCertCore;
 
+/// <summary>
+/// Extension methods for the <see cref="KeyCreationOptions"/> class to map its properties 
+/// to the types used in Azure.Security.KeyVault.Certificates and System.Security.Cryptography.
+/// </summary>
 public static class KeyCreationOptionsExtensions
 {
    /// <summary>
@@ -30,38 +34,38 @@ public static class KeyCreationOptionsExtensions
    }
 
    /// <summary>
-   /// Gets the <see cref="CertificateKeyCurveName"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurveName"/> property.
+   /// Gets the <see cref="CertificateKeyCurveName"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurve"/> property.
    /// </summary>
    /// <param name="options">The EC key creation options.</param>
    public static CertificateKeyCurveName GetCertificateKeyCurveName(this EcKeyCreationOptions options)
    {
       ArgumentNullException.ThrowIfNull(options);
 
-      return options.KeyCurveName.ToUpperInvariant() switch
+      return options.KeyCurve switch
       {
-         "P256" => CertificateKeyCurveName.P256,
-         "P256K" => CertificateKeyCurveName.P256K,
-         "P384" => CertificateKeyCurveName.P384,
-         "P521" => CertificateKeyCurveName.P521,
-         _ => throw new NotSupportedException($"Unsupported EC key curve name '{options.KeyCurveName}'. Supported values are: P256, P256K, P384, P521.")
+         EcKeyCurve.P256 => CertificateKeyCurveName.P256,
+         EcKeyCurve.P256K => CertificateKeyCurveName.P256K,
+         EcKeyCurve.P384 => CertificateKeyCurveName.P384,
+         EcKeyCurve.P521 => CertificateKeyCurveName.P521,
+         _ => throw new NotSupportedException($"Unsupported EC key curve name '{options.KeyCurve}'. Supported values are: P256, P256K, P384, P521.")
       };
    }
 
    /// <summary>
-   /// Gets the <see cref="ECCurve"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurveName"/> property.
+   /// Gets the <see cref="ECCurve"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurve"/> property.
    /// </summary>
    /// <param name="options">The EC key creation options.</param>
    public static ECCurve GetEcCurve(this EcKeyCreationOptions options)
    {
       ArgumentNullException.ThrowIfNull(options);
 
-      return options.KeyCurveName.ToUpperInvariant() switch
+      return options.KeyCurve switch
       {
-         "P256" => ECCurve.NamedCurves.nistP256,
-         "P256K" => ECCurve.CreateFromFriendlyName("secp256k1"),
-         "P384" => ECCurve.NamedCurves.nistP384,
-         "P521" => ECCurve.NamedCurves.nistP521,
-         _ => throw new NotSupportedException($"Unsupported EC curve '{options.KeyCurveName}'.")
+         EcKeyCurve.P256 => ECCurve.NamedCurves.nistP256,
+         EcKeyCurve.P256K => ECCurve.CreateFromFriendlyName("secp256k1"),
+         EcKeyCurve.P384 => ECCurve.NamedCurves.nistP384,
+         EcKeyCurve.P521 => ECCurve.NamedCurves.nistP521,
+         _ => throw new NotSupportedException($"Unsupported EC curve '{options.KeyCurve}'.")
       };
    }
 }

--- a/src/AzureCertTools/AzureCertCore/KeyCreationOptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/KeyCreationOptionsExtensions.cs
@@ -1,0 +1,67 @@
+﻿// ----------------------------------------------------------------------------
+// <copyright company="Michael Koster">
+//   Copyright (c) Michael Koster. All rights reserved.
+//   Licensed under the MIT License.
+// </copyright>
+// ----------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using Azure.Security.KeyVault.Certificates;
+
+namespace CertTools.AzureCertCore;
+
+public static class KeyCreationOptionsExtensions
+{
+   /// <summary>
+   /// Gets the <see cref="CertificateKeyType"/> for the certificate based on the type of the <see cref="KeyCreationOptions"/> instance.
+   /// </summary>
+   /// <param name="options">The key creation options.</param>
+   /// <returns>The corresponding <see cref="CertificateKeyType"/>.</returns>
+   public static CertificateKeyType GetCertificateKeyType(this KeyCreationOptions options)
+   {
+      ArgumentNullException.ThrowIfNull(options);
+
+      return options switch
+      {
+         RsaKeyCreationOptions opts => opts.HsmBacked ? CertificateKeyType.RsaHsm : CertificateKeyType.Rsa,
+         EcKeyCreationOptions opts => opts.HsmBacked ? CertificateKeyType.EcHsm : CertificateKeyType.Ec,
+         _ => throw new NotSupportedException($"Unsupported key creation options type '{options.GetType().FullName}'.")
+      };
+   }
+
+   /// <summary>
+   /// Gets the <see cref="CertificateKeyCurveName"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurveName"/> property.
+   /// </summary>
+   /// <param name="options">The EC key creation options.</param>
+   public static CertificateKeyCurveName GetCertificateKeyCurveName(this EcKeyCreationOptions options)
+   {
+      ArgumentNullException.ThrowIfNull(options);
+
+      return options.KeyCurveName.ToUpperInvariant() switch
+      {
+         "P256" => CertificateKeyCurveName.P256,
+         "P256K" => CertificateKeyCurveName.P256K,
+         "P384" => CertificateKeyCurveName.P384,
+         "P521" => CertificateKeyCurveName.P521,
+         _ => throw new NotSupportedException($"Unsupported EC key curve name '{options.KeyCurveName}'. Supported values are: P256, P256K, P384, P521.")
+      };
+   }
+
+   /// <summary>
+   /// Gets the <see cref="ECCurve"/> for the EC key based on the <see cref="EcKeyCreationOptions.KeyCurveName"/> property.
+   /// </summary>
+   /// <param name="options">The EC key creation options.</param>
+   public static ECCurve GetEcCurve(this EcKeyCreationOptions options)
+   {
+      ArgumentNullException.ThrowIfNull(options);
+
+      return options.KeyCurveName.ToUpperInvariant() switch
+      {
+         "P256" => ECCurve.NamedCurves.nistP256,
+         "P256K" => ECCurve.CreateFromFriendlyName("secp256k1"),
+         "P384" => ECCurve.NamedCurves.nistP384,
+         "P521" => ECCurve.NamedCurves.nistP521,
+         _ => throw new NotSupportedException($"Unsupported EC curve '{options.KeyCurveName}'.")
+      };
+   }
+}

--- a/src/AzureCertTools/AzureCertCore/OptionsBase.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsBase.cs
@@ -12,7 +12,7 @@ namespace CertTools.AzureCertCore;
 /// <summary>
 /// Container class for the command line options common to all tools.
 /// </summary>
-public class OptionsBase
+public abstract class OptionsBase
 {
    /// <summary>
    /// Gets or sets the name of the certificate to create in Key Vault.

--- a/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
@@ -12,13 +12,10 @@ namespace CertTools.AzureCertCore;
 /// <summary>
 /// Container class for the command line options common to all tools creating certificates.
 /// </summary>
-public class OptionsCreateBase : OptionsBase
+public abstract class OptionsCreateBase : OptionsBase
 {
    /// <summary>Default key type: RSA software-backed.</summary>
    public const string DefaultKeyType = "Rsa";
-
-   /// <summary>Default RSA key size in bits.</summary>
-   public const int DefaultKeySize = 4096;
 
    /// <summary>Default EC key curve name.</summary>
    public const string DefaultKeyCurveName = "P384";
@@ -45,6 +42,17 @@ public class OptionsCreateBase : OptionsBase
    /// Gets or sets the RSA key size in bits. Applicable only for Rsa and RsaHsm key types. Supported values: 2048, 3072, 4096. Default is 4096.
    /// </summary>
    [Option("KeySize", Required = false, HelpText = "The RSA key size in bits (Rsa and RsaHsm only): 2048, 3072, 4096. Default is 4096.")]
-   public int KeySize { get; set; } = DefaultKeySize;
+   public int KeySize { get; set; } = RsaKeyCreationOptions.DefaultKeySize;
+}
 
+/// <summary>
+/// Container class for the command line options common to all tools creating certificates with a specified x.509 Subject Name.
+/// </summary>
+public abstract class OptionsCreateWithSubjectBase : OptionsCreateBase
+{
+   /// <summary>
+   /// Gets or set the x.509 Subject Name for the certificate.
+   /// </summary>
+   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
+   public required string Subject { get; set; }
 }

--- a/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
@@ -14,17 +14,14 @@ namespace CertTools.AzureCertCore;
 /// </summary>
 public class OptionsCreateBase : OptionsBase
 {
-   /// <summary>
-   /// Gets or set the x.509 Subject Name for the certificate.
-   /// </summary>
-   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
-   public required string Subject { get; set; }
+   /// <summary>Default key type: RSA software-backed.</summary>
+   public const string DefaultKeyType = "Rsa";
 
    /// <summary>
    /// Gets or sets the key type for the certificate private key. Supported values: Ec, EcHsm, Rsa, RsaHsm. Default is Rsa.
    /// </summary>
    [Option("KeyType", Required = false, HelpText = "The key type for the certificate private key: Ec, EcHsm, Rsa, RsaHsm. Default is Rsa.")]
-   public string KeyType { get; set; } = KeyCreationOptions.DefaultKeyType;
+   public string KeyType { get; set; } = DefaultKeyType;
 
    /// <summary>
    /// Gets or sets a value indicating whether the private key is exportable from Azure Key Vault. Default is false.
@@ -36,12 +33,12 @@ public class OptionsCreateBase : OptionsBase
    /// Gets or sets the EC key curve name. Applicable only for Ec and EcHsm key types. Supported values: P256, P256K, P384, P521. Default is P384.
    /// </summary>
    [Option("KeyCurveName", Required = false, HelpText = "The EC key curve name (Ec and EcHsm only): P256, P256K, P384, P521. Default is P384.")]
-   public string KeyCurveName { get; set; } = KeyCreationOptions.DefaultKeyCurveName;
+   public string KeyCurveName { get; set; } = EcKeyCreationOptions.DefaultKeyCurveName;
 
    /// <summary>
    /// Gets or sets the RSA key size in bits. Applicable only for Rsa and RsaHsm key types. Supported values: 2048, 3072, 4096. Default is 4096.
    /// </summary>
    [Option("KeySize", Required = false, HelpText = "The RSA key size in bits (Rsa and RsaHsm only): 2048, 3072, 4096. Default is 4096.")]
-   public int KeySize { get; set; } = KeyCreationOptions.DefaultKeySize;
+   public int KeySize { get; set; } = RsaKeyCreationOptions.DefaultKeySize;
 
 }

--- a/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsCreateBase.cs
@@ -17,6 +17,12 @@ public class OptionsCreateBase : OptionsBase
    /// <summary>Default key type: RSA software-backed.</summary>
    public const string DefaultKeyType = "Rsa";
 
+   /// <summary>Default RSA key size in bits.</summary>
+   public const int DefaultKeySize = 4096;
+
+   /// <summary>Default EC key curve name.</summary>
+   public const string DefaultKeyCurveName = "P384";
+
    /// <summary>
    /// Gets or sets the key type for the certificate private key. Supported values: Ec, EcHsm, Rsa, RsaHsm. Default is Rsa.
    /// </summary>
@@ -33,12 +39,12 @@ public class OptionsCreateBase : OptionsBase
    /// Gets or sets the EC key curve name. Applicable only for Ec and EcHsm key types. Supported values: P256, P256K, P384, P521. Default is P384.
    /// </summary>
    [Option("KeyCurveName", Required = false, HelpText = "The EC key curve name (Ec and EcHsm only): P256, P256K, P384, P521. Default is P384.")]
-   public string KeyCurveName { get; set; } = EcKeyCreationOptions.DefaultKeyCurveName;
+   public string KeyCurveName { get; set; } = DefaultKeyCurveName;
 
    /// <summary>
    /// Gets or sets the RSA key size in bits. Applicable only for Rsa and RsaHsm key types. Supported values: 2048, 3072, 4096. Default is 4096.
    /// </summary>
    [Option("KeySize", Required = false, HelpText = "The RSA key size in bits (Rsa and RsaHsm only): 2048, 3072, 4096. Default is 4096.")]
-   public int KeySize { get; set; } = RsaKeyCreationOptions.DefaultKeySize;
+   public int KeySize { get; set; } = DefaultKeySize;
 
 }

--- a/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
@@ -5,6 +5,9 @@
 // </copyright>
 // ----------------------------------------------------------------------------
 
+using Azure.Core;
+using Azure.Identity;
+
 namespace CertTools.AzureCertCore;
 
 /// <summary>
@@ -121,6 +124,23 @@ public static class OptionsExtensions
          }
       };
    }
+
+   /// <summary>
+   /// Returns an appropriate <see cref="TokenCredential"/> instance based on the authentication options provided in the <see cref="OptionsBase"/> instance.
+   /// </summary>
+   /// <param name="options">The <see cref="OptionsBase"/> instance containing the authentication options.</param>
+   /// <returns>A <see cref="TokenCredential"/> instance.</returns>
+   public static TokenCredential GetTokenCredential(this OptionsBase options) => options switch
+   {
+      { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
+      {
+         TenantId = options.TenantId,
+         ClientId = options.ClientId,
+         RedirectUri = new Uri("http://localhost")
+      }),
+      { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
+      _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
+   };
 
    private static void PrintError(string message)
    {

--- a/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
@@ -113,7 +113,13 @@ public static class OptionsExtensions
          "EC" or "ECHSM" => new EcKeyCreationOptions
          {
             Exportable = options.Exportable,
-            KeyCurveName = options.KeyCurveName,
+            KeyCurve = options.KeyCurveName.ToUpperInvariant() switch
+            {
+               "P256" => EcKeyCurve.P256,
+               "P256K" => EcKeyCurve.P256K,
+               "P384" => EcKeyCurve.P384,
+               _ => EcKeyCurve.P521,
+            },
             HsmBacked = options.KeyType.Equals("ECHSM", StringComparison.OrdinalIgnoreCase)
          },
          _ => new RsaKeyCreationOptions

--- a/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
@@ -5,8 +5,6 @@
 // </copyright>
 // ----------------------------------------------------------------------------
 
-using CommandLine.Text;
-
 namespace CertTools.AzureCertCore;
 
 /// <summary>
@@ -96,6 +94,32 @@ public static class OptionsExtensions
       }
 
       return true;
+   }
+
+   /// <summary>
+   /// Converts the key creation related options from the provided OptionsCreateBase instance into a <see cref="KeyCreationOptions"/> object.
+   /// </summary>
+   /// <param name="options">The OptionsCreateBase instance containing the key creation options.</param>
+   /// <returns>A <see cref="KeyCreationOptions"/> object representing the key creation options.</returns>
+   public static KeyCreationOptions GetKeyCreationOptions(this OptionsCreateBase options)
+   {
+      ArgumentNullException.ThrowIfNull(options);
+
+      return options.KeyType.ToUpperInvariant() switch
+      {
+         "EC" or "ECHSM" => new EcKeyCreationOptions
+         {
+            Exportable = options.Exportable,
+            KeyCurveName = options.KeyCurveName,
+            HsmBacked = options.KeyType.Equals("ECHSM", StringComparison.OrdinalIgnoreCase)
+         },
+         _ => new RsaKeyCreationOptions
+         {
+            Exportable = options.Exportable,
+            KeySize = options.KeySize,
+            HsmBacked = options.KeyType.Equals("RSAHSM", StringComparison.OrdinalIgnoreCase)
+         }
+      };
    }
 
    private static void PrintError(string message)

--- a/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
+++ b/src/AzureCertTools/AzureCertCore/OptionsExtensions.cs
@@ -108,26 +108,30 @@ public static class OptionsExtensions
    {
       ArgumentNullException.ThrowIfNull(options);
 
-      return options.KeyType.ToUpperInvariant() switch
+      string keyType = options.KeyType.Trim().ToUpperInvariant();
+      string keyCurveName = options.KeyCurveName.Trim().ToUpperInvariant();
+
+      return keyType switch
       {
          "EC" or "ECHSM" => new EcKeyCreationOptions
          {
             Exportable = options.Exportable,
-            KeyCurve = options.KeyCurveName.ToUpperInvariant() switch
+            KeyCurve = keyCurveName switch
             {
                "P256" => EcKeyCurve.P256,
                "P256K" => EcKeyCurve.P256K,
                "P384" => EcKeyCurve.P384,
                _ => EcKeyCurve.P521,
             },
-            HsmBacked = options.KeyType.Equals("ECHSM", StringComparison.OrdinalIgnoreCase)
+            HsmBacked = keyType.Equals("ECHSM", StringComparison.OrdinalIgnoreCase)
          },
-         _ => new RsaKeyCreationOptions
+         "RSA" or "RSAHSM" => new RsaKeyCreationOptions
          {
             Exportable = options.Exportable,
             KeySize = options.KeySize,
-            HsmBacked = options.KeyType.Equals("RSAHSM", StringComparison.OrdinalIgnoreCase)
-         }
+            HsmBacked = keyType.Equals("RSAHSM", StringComparison.OrdinalIgnoreCase)
+         },
+         _ => throw new NotSupportedException($"Unsupported key type '{options.KeyType}'. Supported values are: Ec, EcHsm, Rsa, RsaHsm.")
       };
    }
 

--- a/src/AzureCertTools/AzureCreateIntermediateCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateIntermediateCert/Options.cs
@@ -13,14 +13,8 @@ namespace CertTools.AzureCreateIntermediateCert;
 /// <summary>
 /// Container class for the command line options.
 /// </summary>
-internal class Options : OptionsCreateBase
+internal class Options : OptionsCreateWithSubjectBase
 {
-   /// <summary>
-   /// Gets or set the x.509 Subject Name for the certificate.
-   /// </summary>
-   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
-   public required string Subject { get; set; }
-
    /// <summary>
    /// Gets or sets the name of the signer certificate stored in Key Vault.
    /// </summary>

--- a/src/AzureCertTools/AzureCreateIntermediateCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateIntermediateCert/Options.cs
@@ -16,6 +16,12 @@ namespace CertTools.AzureCreateIntermediateCert;
 internal class Options : OptionsCreateBase
 {
    /// <summary>
+   /// Gets or set the x.509 Subject Name for the certificate.
+   /// </summary>
+   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
+   public required string Subject { get; set; }
+
+   /// <summary>
    /// Gets or sets the name of the signer certificate stored in Key Vault.
    /// </summary>
    [Option("SignerCertificateName", Required = true, HelpText = "The name of the signer certificate in Key Vault")]

--- a/src/AzureCertTools/AzureCreateIntermediateCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateIntermediateCert/Program.cs
@@ -6,7 +6,6 @@
 // ----------------------------------------------------------------------------
 
 using Azure.Core;
-using Azure.Identity;
 using CertTools.AzureCertCore;
 using CommandLine;
 
@@ -34,17 +33,7 @@ internal static class Program
       ConsoleHelper.PrintToolInfo();
 
       // Create the token provider
-      TokenCredential credentials = options switch
-      {
-         { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-         {
-            TenantId = options.TenantId,
-            ClientId = options.ClientId,
-            RedirectUri = new Uri("http://localhost")
-         }),
-         { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
-         _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
-      };
+      TokenCredential credentials = options.GetTokenCredential();
 
       Uri keyVaultUri = new(options.KeyVaultUri);
 

--- a/src/AzureCertTools/AzureCreateIntermediateCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateIntermediateCert/Program.cs
@@ -48,13 +48,7 @@ internal static class Program
 
       Uri keyVaultUri = new(options.KeyVaultUri);
 
-      var cert = CertificateWorker.CreateIntermediateCertAsync(options.CertificateName, options.Subject, options.SignerCertificateName, options.ExpireMonths, options.PathLengthConstraint, keyVaultUri, credentials, new KeyCreationOptions
-      {
-         KeyType = options.KeyType,
-         Exportable = options.Exportable,
-         KeyCurveName = options.KeyCurveName,
-         KeySize = options.KeySize
-      }).Result;
+      var cert = CertificateWorker.CreateIntermediateCertAsync(options.CertificateName, options.Subject, options.SignerCertificateName, options.ExpireMonths, options.PathLengthConstraint, keyVaultUri, credentials, options.GetKeyCreationOptions()).Result;
 
       Console.WriteLine($"Certificate created: name={cert}, Key Vault={keyVaultUri}");
    }

--- a/src/AzureCertTools/AzureCreateRootCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateRootCert/Options.cs
@@ -13,14 +13,8 @@ namespace CertTools.AzureCreateRootCert;
 /// <summary>
 /// Container class for the command line options.
 /// </summary>
-internal class Options : OptionsCreateBase
+internal class Options : OptionsCreateWithSubjectBase
 {
-   /// <summary>
-   /// Gets or set the x.509 Subject Name for the certificate.
-   /// </summary>
-   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
-   public required string Subject { get; set; }
-
    /// <summary>
    /// Gets or sets the number of month until the certificate expires.
    /// </summary>

--- a/src/AzureCertTools/AzureCreateRootCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateRootCert/Options.cs
@@ -16,6 +16,12 @@ namespace CertTools.AzureCreateRootCert;
 internal class Options : OptionsCreateBase
 {
    /// <summary>
+   /// Gets or set the x.509 Subject Name for the certificate.
+   /// </summary>
+   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
+   public required string Subject { get; set; }
+
+   /// <summary>
    /// Gets or sets the number of month until the certificate expires.
    /// </summary>
    [Option("ExpireMonths", Required = false, HelpText = "The number of months until the certificate expires, default if not specified is 240 months.")]

--- a/src/AzureCertTools/AzureCreateRootCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateRootCert/Program.cs
@@ -6,7 +6,6 @@
 // ----------------------------------------------------------------------------
 
 using Azure.Core;
-using Azure.Identity;
 using CertTools.AzureCertCore;
 using CommandLine;
 
@@ -34,17 +33,7 @@ internal static class Program
       ConsoleHelper.PrintToolInfo();
 
       // Create the token provider
-      TokenCredential credentials = options switch
-      {
-         { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-         {
-            TenantId = options.TenantId,
-            ClientId = options.ClientId,
-            RedirectUri = new Uri("http://localhost")
-         }),
-         { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
-         _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
-      };
+      TokenCredential credentials = options.GetTokenCredential();
 
       Uri keyVaultUri = new(options.KeyVaultUri);
 

--- a/src/AzureCertTools/AzureCreateRootCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateRootCert/Program.cs
@@ -48,13 +48,7 @@ internal static class Program
 
       Uri keyVaultUri = new(options.KeyVaultUri);
 
-      var cert = await CertificateWorker.CreateRootCertAsync(options.CertificateName, options.Subject, options.ExpireMonths, options.PathLengthConstraint, keyVaultUri, credentials, new KeyCreationOptions
-      {
-         KeyType = options.KeyType,
-         Exportable = options.Exportable,
-         KeyCurveName = options.KeyCurveName,
-         KeySize = options.KeySize
-      });
+      var cert = await CertificateWorker.CreateRootCertAsync(options.CertificateName, options.Subject, options.ExpireMonths, options.PathLengthConstraint, keyVaultUri, credentials, options.GetKeyCreationOptions());
 
       Console.WriteLine($"Certificate created: name={cert}, Key Vault={keyVaultUri}");
    }

--- a/src/AzureCertTools/AzureCreateSigningCert/CertificateWorker.cs
+++ b/src/AzureCertTools/AzureCreateSigningCert/CertificateWorker.cs
@@ -125,11 +125,11 @@ internal static class CertificateWorker
 
    private static AsymmetricAlgorithm CreateKeyPair(KeyCreationOptions keyOptions)
    {
-      return keyOptions.KeyType.ToUpperInvariant() switch
+      return keyOptions switch
       {
-         "RSA" or "RSAHSM" => RSA.Create(keyOptions.KeySize),
-         "EC" or "ECHSM" => ECDsa.Create(GetEcCurve(keyOptions.KeyCurveName)),
-         _ => throw new NotSupportedException($"Unsupported key type '{keyOptions.KeyType}'.")
+         RsaKeyCreationOptions rsaOptions => RSA.Create(rsaOptions.KeySize),
+         EcKeyCreationOptions ecOptions => ECDsa.Create(ecOptions.GetEcCurve()),
+         _ => throw new NotSupportedException($"Unsupported key type '{keyOptions.GetType()}'.")
       };
    }
 
@@ -142,15 +142,6 @@ internal static class CertificateWorker
          _ => throw new NotSupportedException($"Unsupported key algorithm '{keyPair.GetType().Name}'.")
       };
    }
-
-   private static ECCurve GetEcCurve(string keyCurveName) => keyCurveName.ToUpperInvariant() switch
-   {
-      "P256" => ECCurve.NamedCurves.nistP256,
-      "P256K" => ECCurve.CreateFromFriendlyName("secp256k1"),
-      "P384" => ECCurve.NamedCurves.nistP384,
-      "P521" => ECCurve.NamedCurves.nistP521,
-      _ => throw new NotSupportedException($"Unsupported EC curve '{keyCurveName}'.")
-   };
 
    private static void AddKeyUsageExtensions(CertificateRequest certSigningRequest)
    {

--- a/src/AzureCertTools/AzureCreateSigningCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateSigningCert/Options.cs
@@ -16,6 +16,12 @@ namespace CertTools.AzureCreateSigningCert;
 internal class Options : OptionsCreateBase
 {
    /// <summary>
+   /// Gets or set the x.509 Subject Name for the certificate.
+   /// </summary>
+   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
+   public required string Subject { get; set; }
+
+   /// <summary>
    /// Gets or sets the name of the certificate PFX file to create.
    /// </summary>
    [Option("FileName", Required = true, Group = "CertificateNameOrFile", HelpText = "The absolute path for the PFX file to create.")]

--- a/src/AzureCertTools/AzureCreateSigningCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateSigningCert/Options.cs
@@ -13,14 +13,8 @@ namespace CertTools.AzureCreateSigningCert;
 /// <summary>
 /// Container class for the command line options.
 /// </summary>
-internal class Options : OptionsCreateBase
+internal class Options : OptionsCreateWithSubjectBase
 {
-   /// <summary>
-   /// Gets or set the x.509 Subject Name for the certificate.
-   /// </summary>
-   [Option("Subject", Required = true, HelpText = "The subject name for the certificate in the form \"CN=<subject name>\"")]
-   public required string Subject { get; set; }
-
    /// <summary>
    /// Gets or sets the name of the certificate PFX file to create.
    /// </summary>

--- a/src/AzureCertTools/AzureCreateSigningCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateSigningCert/Program.cs
@@ -6,7 +6,6 @@
 // ----------------------------------------------------------------------------
 
 using Azure.Core;
-using Azure.Identity;
 using CertTools.AzureCertCore;
 using CommandLine;
 
@@ -49,17 +48,7 @@ internal static class Program
       }
 
       // Create the token provider
-      TokenCredential credentials = options switch
-      {
-         { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-         {
-            TenantId = options.TenantId,
-            ClientId = options.ClientId,
-            RedirectUri = new Uri("http://localhost")
-         }),
-         { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
-         _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
-      };
+      TokenCredential credentials = options.GetTokenCredential();
 
       Uri keyVaultUri = new(options.KeyVaultUri);
 

--- a/src/AzureCertTools/AzureCreateSigningCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateSigningCert/Program.cs
@@ -65,24 +65,12 @@ internal static class Program
 
       if (!string.IsNullOrEmpty(options.CertificateName))
       {
-         CertificateWorker.KeyVaultCreateSigningCertificateAsync(options.CertificateName, options.Subject, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonths, new KeyCreationOptions
-         {
-            KeyType = options.KeyType,
-            Exportable = options.Exportable,
-            KeyCurveName = options.KeyCurveName,
-            KeySize = options.KeySize
-         }).Wait();
+         CertificateWorker.KeyVaultCreateSigningCertificateAsync(options.CertificateName, options.Subject, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonths, options.GetKeyCreationOptions()).Wait();
          Console.WriteLine($"Certificate created: name={options.CertificateName}, Key Vault={keyVaultUri}");
       }
       else if (!string.IsNullOrEmpty(options.FileName))
       {
-         CertificateWorker.LocalCreateSigningCertificateAsync(options.FileName, options.Password, options.Subject, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonths, new KeyCreationOptions
-         {
-            KeyType = options.KeyType,
-            Exportable = options.Exportable,
-            KeyCurveName = options.KeyCurveName,
-            KeySize = options.KeySize
-         }).Wait();
+         CertificateWorker.LocalCreateSigningCertificateAsync(options.FileName, options.Password, options.Subject, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonths, options.GetKeyCreationOptions()).Wait();
          Console.WriteLine($"PFX file created: {options.FileName}");
       }
       else

--- a/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
@@ -95,7 +95,7 @@ internal static class CertificateWorker
 
       var (signerHashAlgorithm, signerSignaturePadding) = keyOptions switch
       {
-         EcKeyCreationOptions ecOptions => (GetEcSignerHashAlgorithm(ecOptions.KeyCurveName), null),
+         EcKeyCreationOptions ecOptions => (GetEcSignerHashAlgorithm(ecOptions.KeyCurve), null),
          RsaKeyCreationOptions => (HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
          _ => throw new NotSupportedException($"Unsupported key type '{keyOptions.GetType()}'."),
       };
@@ -149,10 +149,10 @@ internal static class CertificateWorker
          new Oid(Constants.AspNetHttpsEnhancedKeyUsageOid, Constants.AspNetHttpsEnhancedKeyUsageOidFriendlyName), [Constants.AspNetCurrentCertificateVersion]), false));
    }
 
-   private static HashAlgorithmName GetEcSignerHashAlgorithm(string keyCurveName) => keyCurveName.ToUpperInvariant() switch
+   private static HashAlgorithmName GetEcSignerHashAlgorithm(EcKeyCurve keyCurve) => keyCurve switch
    {
-      "P256" or "P256K" => HashAlgorithmName.SHA256,
-      "P521" => HashAlgorithmName.SHA512,
+      EcKeyCurve.P256 or EcKeyCurve.P256K => HashAlgorithmName.SHA256,
+      EcKeyCurve.P521 => HashAlgorithmName.SHA512,
       _ => HashAlgorithmName.SHA384,
    };
 }

--- a/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
@@ -90,11 +90,11 @@ internal static class CertificateWorker
       // Stage 3: Get the CSR from the certificate operation
       var certOperationCertSigningRequest = certificateOperation.Properties.Csr;
 
-      var (signerHashAlgorithm, signerSignaturePadding) = keyOptions.KeyType.ToUpperInvariant() switch
+      var (signerHashAlgorithm, signerSignaturePadding) = keyOptions switch
       {
-         "EC" or "ECHSM" => (GetEcSignerHashAlgorithm(keyOptions.KeyCurveName), (RSASignaturePadding?)null),
-         "RSA" or "RSAHSM" => (HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
-         _ => throw new NotSupportedException($"Unsupported key type '{keyOptions.KeyType}'."),
+         EcKeyCreationOptions ecOptions => (GetEcSignerHashAlgorithm(ecOptions.KeyCurveName), null),
+         RsaKeyCreationOptions => (HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+         _ => throw new NotSupportedException($"Unsupported key type '{keyOptions.GetType()}'."),
       };
 
       // Stage 4: Get the .NET CSR object

--- a/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/CertificateWorker.cs
@@ -20,6 +20,9 @@ namespace CertTools.AzureCreateSslServerCert;
 /// </summary>
 internal static class CertificateWorker
 {
+   /// <summary>RSA key size in bits</summary>
+   private const int RsaKeySize = 4096;
+
    /// <summary>
    /// Create SSL server certificate as an asynchronous operation.
    /// </summary>
@@ -118,7 +121,7 @@ internal static class CertificateWorker
       {
          Flags = CspProviderFlags.UseArchivableKey
       };
-      using var rsaKeyPair = new RSACryptoServiceProvider(CertificateWorkerCore.RsaKeySize, cspParameter);
+      using var rsaKeyPair = new RSACryptoServiceProvider(RsaKeySize, cspParameter);
 
       // Create the CSR
       var subjectName = new X500DistinguishedName(distinguishedName);

--- a/src/AzureCertTools/AzureCreateSslServerCert/Options.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/Options.cs
@@ -13,19 +13,13 @@ namespace CertTools.AzureCreateSslServerCert;
 /// <summary>
 /// Container class for the command line options.
 /// </summary>
-internal class Options
+internal class Options : OptionsCreateBase
 {
    /// <summary>
    /// Gets or set the x.509 Subject Name for the certificate.
    /// </summary>
    [Option("FQDN", Required = true, HelpText = "The fully qualified DNS domain name")]
    public required string FQDN { get; set; }
-
-   /// <summary>
-   /// Gets or sets the name of the certificate to create in Key Vault.
-   /// </summary>
-   [Option("CertificateName", Required = true, HelpText = "The name of the file to export the certificate to (PFX and CER) / Azure KeyVault Certificate Name")]
-   public required string CertificateName { get; set; }
 
    /// <summary>
    /// Gets or sets the the flag on whether to create the certificate locally or on KeyVault
@@ -50,64 +44,4 @@ internal class Options
    /// </summary>
    [Option("ExpireMonth", Required = false, HelpText = "The number of month until the certificate expires, default if not specifed is 1 month.")]
    public int ExpireMonth { get; set; } = 1;
-
-   /// <summary>
-   /// Gets or sets the Azure Key Vault URI where to upload the certificate.
-   /// </summary>
-   [Option("KeyVaultUri", Required = true, HelpText = "The URI to an Azure Key Vault")]
-   public required string KeyVaultUri { get; set; }
-
-   /// <summary>
-   /// Gets or sets the Entra ID Tenant ID.
-   /// </summary>
-   [Option("TenantId", Required = true, HelpText = "The Azure Entra ID Tenant ID to authenticate access to Key Vault")]
-   public required string TenantId { get; set; }
-
-   /// <summary>
-   /// Gets or sets the Entra ID Application (Client) ID.
-   /// </summary>
-   [Option("ClientId", Required = true, HelpText = "The Azure Entra ID Application (Client) ID of the application accessing Key Vault")]
-   public required string ClientId { get; set; }
-
-   /// <summary>
-   /// Gets or sets the interactive login flag.
-   /// </summary>
-   [Option("Interactive", Required = true, SetName="Interactive", HelpText = "Use interactive login")]
-   public required bool Interactive { get; set; }
-
-   /// <summary>
-   /// Gets or sets the Entra ID Application (Client) Secret.
-   /// </summary>
-   [Option("ClientSecret", Required = true, SetName="ClientSecret", HelpText = "The Azure Entra ID Application (Client) Secret of the application accessing Key Vault")]
-   public required string ClientSecret { get; set; }
-
-   /// <summary>
-   /// Gets or sets the managed identity login flag.
-   /// </summary>
-   [Option("WorkloadIdentity", Required = true, SetName = "WorkloadIdentity", HelpText = "Use Workload Identity to access Key Vault")]
-   public required bool WorkloadIdentity { get; set; }
-
-   /// <summary>
-   /// Gets or sets the key type for the certificate private key. Supported values: Ec, EcHsm, Rsa, RsaHsm. Default is Rsa.
-   /// </summary>
-   [Option("KeyType", Required = false, HelpText = "The key type for the certificate private key: Ec, EcHsm, Rsa, RsaHsm. Default is Rsa.")]
-   public string KeyType { get; set; } = KeyCreationOptions.DefaultKeyType;
-
-   /// <summary>
-   /// Gets or sets a value indicating whether the private key is exportable from Azure Key Vault. Default is false.
-   /// </summary>
-   [Option("Exportable", Required = false, HelpText = "Whether the private key is exportable from Azure Key Vault. Default is false.")]
-   public bool Exportable { get; set; } = false;
-
-   /// <summary>
-   /// Gets or sets the EC key curve name. Applicable only for Ec and EcHsm key types. Supported values: P256, P256K, P384, P521. Default is P384.
-   /// </summary>
-   [Option("KeyCurveName", Required = false, HelpText = "The EC key curve name (Ec and EcHsm only): P256, P256K, P384, P521. Default is P384.")]
-   public string KeyCurveName { get; set; } = KeyCreationOptions.DefaultKeyCurveName;
-
-   /// <summary>
-   /// Gets or sets the RSA key size in bits. Applicable only for Rsa and RsaHsm key types. Supported values: 2048, 3072, 4096. Default is 4096.
-   /// </summary>
-   [Option("KeySize", Required = false, HelpText = "The RSA key size in bits (Rsa and RsaHsm only): 2048, 3072, 4096. Default is 4096.")]
-   public int KeySize { get; set; } = KeyCreationOptions.DefaultKeySize;
 }

--- a/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
@@ -76,13 +76,7 @@ internal static class Program
 
          Uri keyVaultUri = new(options.KeyVaultUri);
 
-         var resultName = await CertificateWorker.CreateSslServerCertificateAsync(options.CertificateName, options.FQDN, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonth, options.Local, options.Password, new KeyCreationOptions
-         {
-            KeyType = options.KeyType,
-            Exportable = options.Exportable,
-            KeyCurveName = options.KeyCurveName,
-            KeySize = options.KeySize
-         });
+         var resultName = await CertificateWorker.CreateSslServerCertificateAsync(options.CertificateName, options.FQDN, options.SignerCertificateName, keyVaultUri, credentials, options.ExpireMonth, options.Local, options.Password, options.GetKeyCreationOptions());
          Console.WriteLine($"Certificate created: {resultName}");
 
          result = 0;

--- a/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
@@ -7,7 +7,6 @@
 
 using System.Text;
 using Azure.Core;
-using Azure.Identity;
 using CertTools.AzureCertCore;
 using CommandLine;
 
@@ -62,17 +61,7 @@ internal static class Program
       try
       {
          // Create the token provider
-         TokenCredential credentials = options switch
-         {
-            { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-            {
-               TenantId = options.TenantId,
-               ClientId = options.ClientId,
-               RedirectUri = new Uri("http://localhost")
-            }),
-            { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
-            _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
-         };
+         TokenCredential credentials = options.GetTokenCredential();
 
          Uri keyVaultUri = new(options.KeyVaultUri);
 

--- a/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
+++ b/src/AzureCertTools/AzureCreateSslServerCert/Program.cs
@@ -23,22 +23,17 @@ internal static class Program
    /// <param name="args">The args</param>
    static async Task<int> Main(string[] args)
    {
-      Console.WriteLine("Crypto Tools - Azure Key Vault create SSL Server certificate");
-
       int result = 1;
 
-      // Parse the command line options, get at least SubjectName and Name
-      var options = Parser.Default.ParseArguments<Options>(args).Value;
+      // Parse the command line options
+      var options = Parser.Default.ParseArguments<Options>(args).Value.Validate();
       if (options == null)
       {
          return result;
       }
 
-      // Validate key creation options
-      if (!OptionsExtensions.ValidateKeyCreationOptions(options.KeyType, options.KeyCurveName, options.KeySize))
-      {
-         return result;
-      }
+      // Write header
+      ConsoleHelper.PrintToolInfo();
 
       if (options.Local)
       {

--- a/src/AzureCertTools/AzureDeleteCert/Program.cs
+++ b/src/AzureCertTools/AzureDeleteCert/Program.cs
@@ -6,7 +6,6 @@
 // ----------------------------------------------------------------------------
 
 using Azure.Core;
-using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using CertTools.AzureCertCore;
 using CommandLine;
@@ -35,17 +34,7 @@ internal static class Program
       ConsoleHelper.PrintToolInfo();
 
       // Create the token provider
-      TokenCredential credentials = options switch
-      {
-         { Interactive: true } => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions
-         {
-            TenantId = options.TenantId,
-            ClientId = options.ClientId,
-            RedirectUri = new Uri("http://localhost")
-         }),
-         { WorkloadIdentity: true } => new WorkloadIdentityCredential(),
-         _ => new ClientSecretCredential(options.TenantId, options.ClientId, options.ClientSecret)
-      };
+      TokenCredential credentials = options.GetTokenCredential();
 
       var keyVaultUri = new Uri(options.KeyVaultUri);
       var client = new CertificateClient(keyVaultUri, credentials);


### PR DESCRIPTION
Add a class hierarchy around KeyCreationOptions to have cleaner extensibility in the future for new private key algorithms and decouple it from how options are provided via command line.
This also allows to reduce dispatching on string comparisons in the certificate issuing algorithms.
Additionally, TokenCredential instantiation is unified across all utilities and moved into a common class.
Derive Options in AzureCreateSslServerCert from OptionsCreateBase